### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @kiddom/AndroidDraw-codeowners
+# Managed by CODEOWNERS rollout
+* @kiddom/androiddraw-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kiddom/AndroidDraw-codeowners


### PR DESCRIPTION
Create repo codeowners team, add top engineering contributors, and point CODEOWNERS to the team.